### PR TITLE
testing github action on externalIP and port 80

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -22,7 +22,9 @@ jobs:
           cache: false
           start-args: '--static-ip 192.168.49.2'
       - name: test cluster
-        run: kubectl get pods -A
+        run: |
+          minikube ip
+          kubectl get pods -A
       - name: build image
         run: |
           export SHELL=/bin/bash
@@ -51,5 +53,7 @@ jobs:
         run: |
           kubectl port-forward svc/omero-web 8080:80 --address='0.0.0.0' &
           sleep 30s
+          echo "localhost:8080"
           curl -I localhost:8080
+          echo "192.168.49.2:80"
           curl -I 192.168.49.2

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -19,6 +20,7 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           cache: false
+          start-args: '--static-ip 192.168.49.2'
       - name: test cluster
         run: kubectl get pods -A
       - name: build image
@@ -47,6 +49,7 @@ jobs:
           kubectl exec omero-server -- bash -c "/opt/omero/server/server_venv/bin/omero login -u root -w omero -s 127.0.0.1:4064"
       - name: test web
         run: |
-          kubectl port-forward svc/omero-web 8080:4080 --address='0.0.0.0' &
+          kubectl port-forward svc/omero-web 8080:80 --address='0.0.0.0' &
           sleep 30s
           curl -I localhost:8080
+          curl -I 192.168.49.2

--- a/local_k8s/k8s_ymls/omero-rw-web.yml
+++ b/local_k8s/k8s_ymls/omero-rw-web.yml
@@ -27,9 +27,6 @@ spec:
           env:
             - name: CONFIG_omero_web_server__list
               value: '[["omero-server", 4064, "omero"]]'
-          #ports:
-          #- containerPort: 4080
-          #  protocol: TCP
           volumeMounts:
             - name: omero-static-rw
               mountPath: /opt/omero/web/OMERO.web/var
@@ -66,14 +63,9 @@ kind: Service
 metadata:
   name: omero-rw-web
 spec:
-  type: LoadBalancer
+  type: NodePort
   selector:
     app: omero-rw-web
-#   ports:
-#   - name: web
-#     port: 4080
-#     targetPort: 4080
-#     protocol: TCP
   ports:
   - name: http
     port: 80
@@ -82,4 +74,4 @@ spec:
   - name: https
     port: 443
     targetPort: 443
-    protocol: TCP 
+    protocol: TCP

--- a/local_k8s/k8s_ymls/omero-web-direct.yml
+++ b/local_k8s/k8s_ymls/omero-web-direct.yml
@@ -38,7 +38,7 @@ kind: Service
 metadata:
   name: omero-web-direct
 spec:
-  type: LoadBalancer
+  type: NodePort
   selector:
     app: omero-web-direct
   ports:

--- a/local_k8s/k8s_ymls/omero-web.yml
+++ b/local_k8s/k8s_ymls/omero-web.yml
@@ -63,7 +63,7 @@ kind: Service
 metadata:
   name: omero-web
 spec:
-  type: LoadBalancer
+  type: NodePort
   selector:
     app: omero-web
   ports:

--- a/local_k8s/test/testing_changes.yml
+++ b/local_k8s/test/testing_changes.yml
@@ -12,11 +12,23 @@ spec:
               value: '[["omero-server", 4064, "omero"]]'
           ports:
             - containerPort: 4080
-        - $patch: delete
-          name: nginx
+        - name: nginx
+          image: nginx:1.21.4
+          volumeMounts:
+            - $patch: delete
+              name: nginx-ssl
+            - mountPath: /etc/nginx/conf.d
+              name: nginx-configmap
+              readOnly: true
+            - name: omero-static
+              mountPath: /opt/omero-static
+              subPath: static
+              readOnly: true
+          ports:
+            - containerPort: 80
       volumes:
-        - $patch: delete
-          name: nginx-ssl
+      - $patch: delete
+        name: nginx-ssl
 
 ---
 
@@ -25,14 +37,16 @@ kind: Service
 metadata:
   name: omero-web
 spec:
-  type: LoadBalancer
+  type: NodePort
   selector:
     app: omero-web
   ports:
-   - name: web
-     port: 4080
-     targetPort: 4080
-     protocol: TCP
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  externalIPs:
+  - 192.168.49.2
 
 ---
 


### PR DESCRIPTION
Changed omero-web ymls to use NodePort (LoadBalancer no use on local)
Changed test kustomize to include externalIP for omero-web service and keep nginx (http-only)
Github action local test hopefully starts minikube with static IP to match service externalIP