### PR TITLE
removing scheduling from local test

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-  schedule:
-    - cron: '0 0 * * 0'
 
 jobs:
   test:


### PR DESCRIPTION
Github turns off scheduled workflows after a while, which also seems to turn off the PR and push actions from the same file. So I'm removing the scheduled workflow for now and renaming the file.