### PR TITLE
Update local images to debian 11, omero.server 5.6.10, omero.web 5.23.0

### DIFF
--- a/local_k8s/README.md
+++ b/local_k8s/README.md
@@ -7,7 +7,7 @@ Our local Kubernetes is solely used for testing currently. These templates are n
 4. More persistent port forwarding than `kubectl port-forward`
 
 ## Current tested setup:
-`minikube` running Kubernetes cluster on `CentOS 7`
+`minikube` running Kubernetes cluster on `Rocky 9`
 
 ## Build images
 ```
@@ -16,6 +16,19 @@ cd omero-k8s-templates/local_k8s/containers
 docker build omero-web -t omero-web
 docker build omero-server -t omero-server
 ```
+
+## For testing purposes, create your own SSL certificate
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout nginx.key -out nginx.crt
+cat nginx.key | base64 -w 0
+cat nginx.crt | base64 -w 0
+```
+And put base64 nginx.key and nginx.crt in nginx.sslsecret.yml
+
+## CSRF trusted origins
+When using Django 4 (required by OMERO.web 5.23.0+) with http or https, we need to set the CSRF_TRUSTED_ORIGINS environment variable. This can be set the OMERO config omero.web.csrf_trusted_origins (https://github.com/ome/omero-web/pull/477).
+
+We've put this setting in the Nginx configmap ymls. In nginx_conf_http.yml or nginx_conf_https.yml, replace `http://web_url:port` with your web url and port.
 
 ## Run kubernetes deployments/pods
 ```
@@ -34,8 +47,8 @@ kubectl apply -f omero-web.yml
 ## Forward a local port to an internal pod port, to access OMERO.web
 
 ```
-kubectl apply -f omero-web-direct.yml
 screen -S port-forward
-kubectl port-forward svc/omero-web 6080:4080 --address=0.0.0.0
+kubectl port-forward svc/omero-web 8080:80 --address=0.0.0.0
 ```
-Then access OMERO.web at `localhost:6080`
+Then access OMERO.web at `localhost:8080`
+

--- a/local_k8s/containers/omero-server/Dockerfile
+++ b/local_k8s/containers/omero-server/Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile for omero server
-FROM debian:buster
-# FROM ubuntu:bionic
+FROM debian:bullseye
 
 # Following https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/unix/server-debian10-ice36.html
 
@@ -44,16 +43,13 @@ RUN cat omero-ice36.env >> /etc/profile
 RUN python3 -mvenv /opt/omero/server/server_venv
 RUN /opt/omero/server/server_venv/bin/pip install --upgrade pip
 RUN /opt/omero/server/server_venv/bin/pip install wheel setuptools
-RUN /opt/omero/server/server_venv/bin/pip install https://github.com/ome/zeroc-ice-debian10/releases/download/0.1.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl
+RUN /opt/omero/server/server_venv/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
 RUN /opt/omero/server/server_venv/bin/pip install omero-server[default]
-RUN /opt/omero/server/server_venv/bin/pip install "omero-py>=5.8.0"
+RUN /opt/omero/server/server_venv/bin/pip install omero-py==5.17.0
 RUN /opt/omero/server/server_venv/bin/pip install omego
-RUN /opt/omero/server/server_venv/bin/pip install omero-certificates==0.2.0
-RUN /opt/omero/server/server_venv/bin/pip install omero-cli-transfer>=0.2.0
+RUN /opt/omero/server/server_venv/bin/pip install omero-certificates==0.3.2
+RUN /opt/omero/server/server_venv/bin/pip install omero-cli-transfer==0.8.0
 
-
-#RUN mkdir -p /opt/omero/web/OMERO.web/etc/grid && \
-#    chown -R omero-web /opt/omero/web/OMERO.web
 RUN useradd -ms /bin/bash omero-server
 
 WORKDIR /opt/omero/server
@@ -63,9 +59,6 @@ RUN unzip -q OMERO.server*
 RUN chown -R omero-server OMERO.server-*
 RUN ln -s OMERO.server-*/ OMERO.server
 RUN chown -R omero-server /opt
-
-# RUN mkdir -p /OMERO/certs 
-#RUN chown -R omero-server /OMERO
 
 # Startup scripts, from omero-server-docker
 ADD entrypoint.sh /usr/local/bin/

--- a/local_k8s/containers/omero-web/Dockerfile
+++ b/local_k8s/containers/omero-web/Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile for an omero web client
-FROM debian:buster
-# FROM ubuntu:bionic
+FROM debian:bullseye
 
 # Following https://github.com/ome/omero-web-docker
 
@@ -15,12 +14,11 @@ RUN python3 -m venv /opt/omero/web/venv3
 RUN /opt/omero/web/venv3/bin/pip install --upgrade pip
 RUN /opt/omero/web/venv3/bin/pip install wheel
 
-# EP: As of 2120318 this is the most recent version with a wheel.  No idea why.
-RUN /opt/omero/web/venv3/bin/pip install numpy==1.21.5
+RUN /opt/omero/web/venv3/bin/pip install numpy
 # TODO: Download & check hash function
-RUN /opt/omero/web/venv3/bin/pip install --upgrade https://github.com/ome/zeroc-ice-debian10/releases/download/0.1.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl
-RUN /opt/omero/web/venv3/bin/pip install "omero-py==5.11.1"
-RUN /opt/omero/web/venv3/bin/pip install "omero-web==5.14.0"
+RUN /opt/omero/web/venv3/bin/pip install --upgrade https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
+RUN /opt/omero/web/venv3/bin/pip install omero-py==5.17.0
+RUN /opt/omero/web/venv3/bin/pip install omero-web==5.23.0
 
 RUN /opt/omero/web/venv3/bin/pip install \
         omero-figure \

--- a/local_k8s/k8s_ymls/nginx_conf_http.yml
+++ b/local_k8s/k8s_ymls/nginx_conf_http.yml
@@ -25,3 +25,4 @@ data:
             autoindex off;
         }
     }
+  csrf_trusted_origins: '["http://web_url:port"]'

--- a/local_k8s/k8s_ymls/nginx_conf_https.yml
+++ b/local_k8s/k8s_ymls/nginx_conf_https.yml
@@ -40,3 +40,4 @@ data:
             autoindex off;
         }
     }
+  csrf_trusted_origins: '["http://web_url:port","https://web_url:port"]'

--- a/local_k8s/k8s_ymls/omero-rw-web.yml
+++ b/local_k8s/k8s_ymls/omero-rw-web.yml
@@ -27,6 +27,11 @@ spec:
           env:
             - name: CONFIG_omero_web_server__list
               value: '[["omero-server", 4064, "omero"]]'
+            - name: CONFIG_omero_web_csrf__trusted__origins
+              valueFrom:
+                configMapKeyRef:
+                  name: nginxconfigmap
+                  key: csrf_trusted_origins
           volumeMounts:
             - name: omero-static-rw
               mountPath: /opt/omero/web/OMERO.web/var

--- a/local_k8s/k8s_ymls/omero-web.yml
+++ b/local_k8s/k8s_ymls/omero-web.yml
@@ -27,6 +27,11 @@ spec:
           env:
             - name: CONFIG_omero_web_server__list
               value: '[["omero-readonly-server", 4064, "omero"]]'
+            - name: CONFIG_omero_web_csrf__trusted__origins
+              valueFrom:
+                configMapKeyRef:
+                  name: nginxconfigmap
+                  key: csrf_trusted_origins
           volumeMounts:
             - name: omero-static
               mountPath: /opt/omero/web/OMERO.web/var


### PR DESCRIPTION
Since OMERO web moved to Django 4 (allowed in web 5.22.0, forced in 5.23.0), the new csrf_trusted_origins setting must be used for http and https (any time we use nginx) so I added that setting to the nginx configmap. 

Other dependencies also updated with specific versions. 

Readme updated with better port-forward, more information about SSL certificates and the CSRF trusted origin setting.